### PR TITLE
Update alipayvoice.go

### DIFF
--- a/plugin/alipayvoice/alipayvoice.go
+++ b/plugin/alipayvoice/alipayvoice.go
@@ -2,9 +2,12 @@
 package alipayvoice
 
 import (
+	b64 "encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/FloatTech/floatbox/web"
 	ctrl "github.com/FloatTech/zbpctrl"
 	"github.com/FloatTech/zbputils/control"
 	zero "github.com/wdvxdr1123/ZeroBot"
@@ -27,6 +30,10 @@ func init() { // 插件主体
 	engine.OnPrefix(`支付宝到账`).SetBlock(true).
 		Handle(func(ctx *zero.Ctx) {
 			args := ctx.State["args"].(string)
-			ctx.SendChain(message.Record(fmt.Sprintf(alipayvoiceURL, strings.TrimSpace(args))))
+			if moneyCount, err := strconv.ParseFloat(strings.TrimSpace(args), 64); err == nil && moneyCount > 0 {
+				if data, err := web.GetData(fmt.Sprintf(alipayvoiceURL, moneyCount)); err == nil {
+					ctx.SendChain(message.Record("base64://" + b64.StdEncoding.EncodeToString(data)))
+				}
+			}
 		})
 }


### PR DESCRIPTION
修复了如下问题:

1. 过滤用户输入参数不为数字时的情况
2. 过滤用户输入数字超出范围得不到 API 结果的情况

已经过本地测试，commit 在 GitHub 网页完成。